### PR TITLE
Fix text duplication in MCText (<1.19)

### DIFF
--- a/minecraft/versions/1.18.2-fabric/src/main/kotlin/dev/deftu/textile/minecraft/MCText.kt
+++ b/minecraft/versions/1.18.2-fabric/src/main/kotlin/dev/deftu/textile/minecraft/MCText.kt
@@ -59,7 +59,7 @@ public object MCText {
             }
         }
 
-        return literal(text.string).apply {
+        return literal((text as? TextComponent)?.text ?: text.string).apply {
             this.setStyle(MCTextStyle.wrap(text.style))
             text.siblings.map(::wrap).forEach(this::append)
         }


### PR DESCRIPTION
In older Minecraft versions, `text.string` maps to `getUnformattedText()` which returns the text + all siblings. This caused Textile to append siblings twice. Switched to reading the `text.text` to ignore siblings. Tested in 1.8.9-forge.

Before:
<img width="995" height="556" alt="image" src="https://github.com/user-attachments/assets/2d5246b0-e92c-43dc-bc49-6e804563bbf0" />

After:
<img width="1044" height="302" alt="image" src="https://github.com/user-attachments/assets/ee3659a2-9b17-4656-9d67-88f860942d18" />
